### PR TITLE
Handle DateTime? type in datumDiff method

### DIFF
--- a/packages/datum_generator/lib/src/datum_generator.dart
+++ b/packages/datum_generator/lib/src/datum_generator.dart
@@ -487,6 +487,10 @@ class DatumGenerator extends GeneratorForAnnotation<DatumSerializable> {
         buffer.writeln(
           "      changes['$mapKey'] = $fieldName${type.endsWith('?') ? '?' : ''}.toString();",
         );
+      } else if (type == 'DateTime' || type.startsWith('DateTime?')) {
+        buffer.writeln(
+          "      changes['$mapKey'] = $fieldName${type.endsWith('?') ? '?' : ''}.toIso8601String();",
+        );
       } else {
         buffer.writeln("      changes['$mapKey'] = $fieldName;");
       }


### PR DESCRIPTION
Since `DateTime?` type is a core dart type. We should handle it in generator too...

Related to issue: #12 