### PR TITLE
✨ feat(manager):  added `count()` method

### DIFF
--- a/packages/datum/lib/source/adapter/local_adapter.dart
+++ b/packages/datum/lib/source/adapter/local_adapter.dart
@@ -78,6 +78,14 @@ abstract class LocalAdapter<T extends DatumEntityInterface> {
   /// into a native query for the underlying database (e.g., SQL).
   Future<List<T>> query(DatumQuery query, {String? userId});
 
+  /// Returns the number of locally stored entities that match the given [query].
+  ///
+  /// If [query] is null, all entities in the local data store are counted.
+  ///
+  /// The optional [userId] can be used to restrict the count to entities
+  /// associated with a specific user, if the adapter supports user scoping.
+  Future<int> count({DatumQuery? query, String? userId}) async => 0;
+
   // --- Write Methods ---
 
   /// Create a new entity.

--- a/packages/datum/lib/source/adapter/remote_adapter.dart
+++ b/packages/datum/lib/source/adapter/remote_adapter.dart
@@ -32,6 +32,17 @@ abstract class RemoteAdapter<T extends DatumEntityInterface> {
   /// Return null if the adapter doesn't support reactive queries.
   Stream<List<T>>? watchQuery(DatumQuery query, {String? userId}) => null;
 
+  /// Watches the number of remote entities that match the given [query].
+  ///
+  /// Emits a new count whenever the remote data changes, if the backend
+  /// supports realtime updates.
+  ///
+  /// Returns `null` if the remote adapter does not support watching counts.
+  ///
+  /// The optional [userId] can be used to scope the request to a specific
+  /// user's data when supported by the backend.
+  Stream<int>? watchCount({DatumQuery? query, String? userId}) => null;
+
   // --- One-time Read Methods ---
 
   /// Fetch all items, optionally filtered by a scope.
@@ -45,6 +56,18 @@ abstract class RemoteAdapter<T extends DatumEntityInterface> {
   /// This method should be implemented by adapters to translate a [DatumQuery]
   /// into a native query for the underlying service (e.g., a REST API call).
   Future<List<T>> query(DatumQuery query, {String? userId});
+
+  /// Returns the number of remote entities that match the given [query].
+  ///
+  /// If [query] is null, all entities available from the remote data source
+  /// will be counted.
+  ///
+  /// The optional [userId] can be used to scope the request to a specific
+  /// user's data when supported by the backend.
+  ///
+  /// Implementations should override this method to perform an efficient
+  /// remote count operation instead of fetching all records.
+  Future<int> count({DatumQuery? query, String? userId}) async => 0;
 
   // --- Write Methods ---
 

--- a/packages/datum/lib/source/core/manager/datum_manager.dart
+++ b/packages/datum/lib/source/core/manager/datum_manager.dart
@@ -928,6 +928,19 @@ class DatumManager<T extends DatumEntityInterface> with Disposable {
     });
   }
 
+  /// Watches the number of entities that match the given [query].
+  ///
+  /// Emits a new count whenever the underlying data changes.
+  ///
+  /// If [query] is null, the count includes all entities.
+  ///
+  /// The optional [userId] can be used to restrict the count to
+  /// entities associated with a specific user.
+  Stream<int>? watchCount({DatumQuery? query, String? userId}) {
+    _ensureInitialized();
+    return localAdapter.watchCount(query: query, userId: userId);
+  }
+
   /// Executes a one-time query against the specified data source.
   ///
   /// This provides a powerful way to fetch filtered and sorted data directly
@@ -1512,6 +1525,25 @@ class DatumManager<T extends DatumEntityInterface> with Disposable {
       restrictedRelations: plan.restrictedRelations,
       errors: errors,
     );
+  }
+
+  /// Returns the number of entities that match the given [query].
+  ///
+  /// By default the count is performed against the local data source.
+  /// Set [source] to [DataSource.remote] to count items from the remote adapter.
+  ///
+  /// The optional [userId] can be used to scope the count to a specific user
+  /// when the adapter supports user-based filtering.
+  ///
+  /// If no [query] is provided, all entities are counted.
+  Future<int> count({
+    DatumQuery query = const DatumQuery(),
+    DataSource source = DataSource.local,
+    String? userId,
+  }) async {
+    _ensureInitialized();
+    final adapter = (source == DataSource.local ? localAdapter : remoteAdapter) as dynamic;
+    return adapter.count(query: query, userId: userId);
   }
 
   /// Executes a block of code within a single atomic transaction.


### PR DESCRIPTION
This PR adds a `count()` method to the manager and the related abstract adapters.

The actual implementation of `count()` will be handled by user-defined adapters.
This change is not breaking, and it provides a useful capability for retrieving the number of entities matching a query.

Related issue #11 