### PR TITLE
✨ feat(core): added `queryRaw` method 

### DIFF
--- a/packages/datum/lib/source/adapter/local_adapter.dart
+++ b/packages/datum/lib/source/adapter/local_adapter.dart
@@ -78,6 +78,20 @@ abstract class LocalAdapter<T extends DatumEntityInterface> {
   /// into a native query for the underlying database (e.g., SQL).
   Future<List<T>> query(DatumQuery query, {String? userId});
 
+  /// Executes a raw query against the underlying database.
+  ///
+  /// Bypasses Datum's query system and returns raw rows as `Map<String, dynamic>`.
+  /// Changes made through raw queries may not be tracked by Datum.
+  Future<List<Map<String, dynamic>>> queryRaw(
+    String query, {
+    List<dynamic> variables = const [],
+    String? userId,
+  }) {
+    throw UnimplementedError(
+      'queryRaw is not implemented for this local adapter.',
+    );
+  }
+
   // --- Write Methods ---
 
   /// Create a new entity.

--- a/packages/datum/lib/source/adapter/remote_adapter.dart
+++ b/packages/datum/lib/source/adapter/remote_adapter.dart
@@ -46,6 +46,20 @@ abstract class RemoteAdapter<T extends DatumEntityInterface> {
   /// into a native query for the underlying service (e.g., a REST API call).
   Future<List<T>> query(DatumQuery query, {String? userId});
 
+  /// Executes a raw query against the remote data source.
+  ///
+  /// Bypasses Datum's query system and returns raw rows as `Map<String, dynamic>`.
+  /// Support depends on the remote adapter implementation.
+  Future<List<Map<String, dynamic>>> queryRaw(
+    String query, {
+    List<dynamic> variables = const [],
+    String? userId,
+  }) {
+    throw UnimplementedError(
+      'queryRaw is not implemented for this remote adapter.',
+    );
+  }
+
   // --- Write Methods ---
 
   /// Create a new entity on the remote data source.

--- a/packages/datum/lib/source/core/engine/datum_core.dart
+++ b/packages/datum/lib/source/core/engine/datum_core.dart
@@ -1096,6 +1096,20 @@ class Datum {
     return Datum.manager<T>().query(query, source: source, userId: userId);
   }
 
+  Future<List<Map<String, dynamic>>> queryRaw(
+    String query, {
+    List<Object?> variables = const [],
+    DataSource source = DataSource.local,
+    String? userId,
+  }) async {
+    if (_managers.isEmpty) {
+      throw StateError('No managers registered. Cannot execute raw query.');
+    }
+    final manager = _managers.allManagers.first;
+    final adapter = (source == DataSource.local ? manager.localAdapter : manager.remoteAdapter) as dynamic;
+    return adapter.queryRaw(query, variables: variables, userId: userId);
+  }
+
   /// Fetches related entities with proper type checking for [RelationalDatumEntity]
   Future<List<R>> fetchRelated<P extends DatumEntityInterface, R extends DatumEntityInterface>(
     P parent,

--- a/packages/datum/lib/source/core/engine/datum_core.dart
+++ b/packages/datum/lib/source/core/engine/datum_core.dart
@@ -1098,7 +1098,7 @@ class Datum {
 
   Future<List<Map<String, dynamic>>> queryRaw(
     String query, {
-    List<Object?> variables = const [],
+    List<dynamic> variables = const [],
     DataSource source = DataSource.local,
     String? userId,
   }) async {


### PR DESCRIPTION
Related issue: #11 

Adding query raw method to support querying with raw SQL. I think this needed and doesn't break any thing much.
Those are handled by adapters, so the core would stay mostly the same.