### PR TITLE
🛠️ fix(sync-engine): fix incorrectly update when `vectorClock`(s) are not provided

### DIFF
--- a/packages/datum/lib/source/core/engine/datum_sync_engine.dart
+++ b/packages/datum/lib/source/core/engine/datum_sync_engine.dart
@@ -581,7 +581,22 @@ class DatumSyncEngine<T extends DatumEntityInterface> {
             // Only update if remote is strictly newer
             if (remoteVC.isLessThanOrEqualTo(localVC)) {
               shouldUpdate = false;
-              logger.debug('Skipping remote update for ${remoteItem.id} because local version is newer or same.');
+              logger.debug('Skipping remote update for ${remoteItem.id} because local vector clock is newer or same.');
+            } else if (!localVC.isLessThanOrEqualTo(remoteVC)) {
+              // Concurrent => skip (since no resolver yet)
+              shouldUpdate = false;
+              logger.debug('Skipping remote update for ${remoteItem.id} due to concurrent vector clocks.');
+            }
+          } else {
+            // Fallback logic if vector clocks are nor provided
+            if (remoteItem.version < localItem.version) {
+              shouldUpdate = false;
+              logger.debug('Skipping remote update for ${remoteItem.id} because local version is newer.');
+            } else if (remoteItem.version == localItem.version) {
+              if (!remoteItem.modifiedAt.isAfter(localItem.modifiedAt)) {
+                shouldUpdate = false;
+                logger.debug('Skipping remote update for ${remoteItem.id} because local modifiedAt is newer or same.');
+              }
             }
           }
 


### PR DESCRIPTION
Related issue: #35 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved conflict resolution in remote sync: concurrent updates are now explicitly detected to avoid unintended overwrites.
  * Added a version + modifiedAt tie-breaker so identical-version remote items are skipped unless newer.
  * Clarified sync logging and refined batch processing to make sync behavior more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->