### PR TITLE
 🛠️ fix(generator): Fix incorrect diff detection for collection types (Map/List/Set) and improve generated diff logic

### DIFF
--- a/packages/datum_generator/lib/src/datum_generator.dart
+++ b/packages/datum_generator/lib/src/datum_generator.dart
@@ -431,35 +431,67 @@ class DatumGenerator extends GeneratorForAnnotation<DatumSerializable> {
     buffer.writeln(
       '\n  Map<String, dynamic>? datumDiff(DatumEntityInterface oldVersion) {',
     );
+
+    final excludedFields = {
+      'id',
+      'userId',
+      'createdAt',
+      'modifiedAt',
+      'version',
+      'isDeleted',
+    };
+
     final diffableFields = fields.where((f) {
       final fieldName = _getElementName(f);
-      return ![
-        'id',
-        'userId',
-        'createdAt',
-        'modifiedAt',
-        'version',
-        'isDeleted',
-      ].contains(fieldName);
+      return !excludedFields.contains(fieldName);
     }).toList();
 
     if (diffableFields.isNotEmpty) {
       buffer.writeln('    final old = oldVersion as $className;');
     }
+
     buffer.writeln('    final changes = <String, dynamic>{};');
+
+    // Detect if deep equality is needed
+    final needsDeepEqual = diffableFields.any((f) {
+      final type = f.type.getDisplayString();
+      return type.startsWith('List') ||
+            type.startsWith('Map') ||
+            type.startsWith('Set');
+    });
+
+    // Deep equality helper (only if needed)
+    if (needsDeepEqual) {
+      buffer.writeln('''
+        bool _isEqual(dynamic a, dynamic b) {
+          if (a == b) return true;
+
+          if (a is Map && b is Map) {
+            if (a.length != b.length) return false;
+            for (final key in a.keys) {
+              if (!b.containsKey(key) || !_isEqual(a[key], b[key])) {
+                return false;
+              }
+            }
+            return true;
+          }
+
+          if (a is List && b is List) {
+            if (a.length != b.length) return false;
+            for (int i = 0; i < a.length; i++) {
+              if (!_isEqual(a[i], b[i])) return false;
+            }
+            return true;
+          }
+
+          return false;
+        }
+      ''');
+    }
 
     for (final field in fields) {
       final fieldName = _getElementName(field);
-      if ([
-        'id',
-        'userId',
-        'createdAt',
-        'modifiedAt',
-        'version',
-        'isDeleted',
-      ].contains(fieldName)) {
-        continue;
-      }
+      if (excludedFields.contains(fieldName)) continue;
 
       final mapKey = _getMapKey(field);
       final type = field.type.getDisplayString();
@@ -467,7 +499,17 @@ class DatumGenerator extends GeneratorForAnnotation<DatumSerializable> {
       final isEnum = typeElement != null && typeElement.kind.name == 'ENUM';
       final toGenerator = _getToGenerator(field);
 
-      buffer.writeln("    if ($fieldName != old.$fieldName) {");
+      // Decide comparison strategy
+      final isCollection =
+          type.startsWith('List') ||
+          type.startsWith('Map') ||
+          type.startsWith('Set');
+
+      final compareExpr = (needsDeepEqual && isCollection)
+          ? '!_isEqual($fieldName, old.$fieldName)'
+          : '$fieldName != old.$fieldName';
+
+      buffer.writeln('    if ($compareExpr) {');
 
       if (toGenerator != null) {
         final code = toGenerator.replaceAll('%DATA_PROPERTY%', fieldName);
@@ -509,9 +551,7 @@ class DatumGenerator extends GeneratorForAnnotation<DatumSerializable> {
 
     if (fields.any((f) => _getElementName(f) == 'modifiedAt')) {
       buffer.writeln('    if (changes.isNotEmpty) {');
-      buffer.writeln(
-        "      changes['modifiedAt'] = modifiedAt.toIso8601String();",
-      );
+      buffer.writeln("      changes['modifiedAt'] = modifiedAt.toIso8601String();");
       buffer.writeln("      changes['version'] = version;");
       buffer.writeln('    }');
     }

--- a/packages/datum_generator/lib/src/datum_generator.dart
+++ b/packages/datum_generator/lib/src/datum_generator.dart
@@ -484,7 +484,23 @@ class DatumGenerator extends GeneratorForAnnotation<DatumSerializable> {
             return true;
           }
 
-          return false;
+          if (a is Set && b is Set) {
+            if (a.length != b.length) return false;
+
+            // Ensure each element is matched exactly once (prevents duplicate matching)
+            final unmatched = b.toList();
+            for (final item in a) {
+              final matchIndex = unmatched.indexWhere(
+                (other) => _isEqual(item, other),
+              );
+              if (matchIndex == -1) return false;
+              unmatched.removeAt(matchIndex);
+            }
+
+            return unmatched.isEmpty;
+          }
+
+          return a == b;
         }
       ''');
     }

--- a/packages/datum_generator/lib/src/datum_generator.dart
+++ b/packages/datum_generator/lib/src/datum_generator.dart
@@ -429,7 +429,7 @@ class DatumGenerator extends GeneratorForAnnotation<DatumSerializable> {
     List<dynamic> fields,
   ) {
     buffer.writeln(
-      '\n  Map<String, dynamic>? datumDiff(DatumEntityInterface oldVersion) {',
+      '\n  Map<String, dynamic>? datumDiff(DatumEntityInterface oldVersion, {MapTarget target = MapTarget.local}) {',
     );
 
     final excludedFields = {


### PR DESCRIPTION
## Problem

The current generator compares fields using `!=`, which only checks reference equality.

This causes false-positive diffs for collections like Map and List.  

## Solution

- Add deep equality check for collection types (Map/List/Set)
- Generate a local `_isEqual` helper function (no external dependencies)
- Use deep comparison only when needed
- Only generate `_isEqual` if at least one field requires it

## Improvements

- Avoid unnecessary diff updates for unchanged collections
- Reduce redundant writes and sync operations
- Keep generator output minimal (no unused helper code)
- No additional dependencies introduced

## Notes

- Behavior for primitive types remains unchanged
- Fully backward compatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate change detection for collection-type fields (lists, maps, sets), reducing false-positive change notifications.
  * Context-aware diffing that respects different target contexts for comparisons, improving relevance of detected changes.
  * More reliable and compact handling of modification timestamps to ensure consistent updated-time behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->