### PR TITLE
🛠️ fix(core): fix adapter dropped some global configs and header log got cut out

### DIFF
--- a/packages/datum/lib/source/config/datum_config.dart
+++ b/packages/datum/lib/source/config/datum_config.dart
@@ -279,7 +279,6 @@ class DatumConfig<T extends DatumEntityInterface> extends Equatable {
       syncTimeout: syncTimeout ?? this.syncTimeout,
       // Only copy the resolver if the new type E is assignable from the old type T.
       // This is safe when copyWith is called without a new generic type.
-      // This is safe when copyWith is called without a new generic type.
       defaultConflictResolver: defaultConflictResolver ?? (this.defaultConflictResolver is DatumConflictResolver<E> ? this.defaultConflictResolver as DatumConflictResolver<E> : null),
       defaultUserSwitchStrategy: defaultUserSwitchStrategy ?? this.defaultUserSwitchStrategy,
       initialUserId: initialUserId ?? this.initialUserId,

--- a/packages/datum/lib/source/core/engine/_internal.dart
+++ b/packages/datum/lib/source/core/engine/_internal.dart
@@ -7,6 +7,7 @@ import 'package:datum/source/core/engine/datum_core.dart';
 import 'package:datum/source/core/engine/datum_observer.dart';
 import 'package:datum/source/core/manager/datum_manager.dart';
 import 'package:datum/source/core/middleware/datum_middleware.dart';
+import 'package:datum/source/core/models/datum_sync_options.dart';
 
 import 'package:datum/source/core/resolver/conflict_resolution.dart';
 
@@ -52,7 +53,12 @@ class AdapterPairImpl<T extends DatumEntityInterface> implements AdapterPair {
   DatumManager<T> createManager(Datum datum) {
     // This is a testing hook. If the config is a special type, return the mock manager from it.
     // This allows us to inject a mock manager during Datum.initialize() in tests.
-    final registrationConfig = config ?? datum.config.copyWith<T>();
+    final registrationConfig = config ?? datum.config.copyWith<T>(
+      defaultConflictResolver: (datum.config.defaultConflictResolver != null)
+          ? DatumConflictResolverAdapter<T>(datum.config.defaultConflictResolver!)
+          : null,
+      defaultSyncOptions: datum.config.defaultSyncOptions?.toTyped<T>()
+    );
     if (registrationConfig is CustomManagerConfig<T>) {
       final customConfig = registrationConfig;
       // Return the mock manager provided by the custom config.
@@ -65,14 +71,14 @@ class AdapterPairImpl<T extends DatumEntityInterface> implements AdapterPair {
     final manager = DatumManager<T>(
       localAdapter: local,
       remoteAdapter: remote,
-      conflictResolver: conflictResolver,
+      conflictResolver: conflictResolver ?? registrationConfig.defaultConflictResolver,
       localObservers: observers,
       globalObservers: datum.globalObservers,
       middlewares: middlewares,
       datumConfig: registrationConfig,
       connectivity: datum.connectivityChecker,
       logger: datum.logger,
-      syncRequestStrategy: syncRequestStrategy,
+      syncRequestStrategy: syncRequestStrategy ?? registrationConfig.syncRequestStrategy,
       persistence: datum.persistence,
       userChangeStream: datum.userChangeStream,
     );

--- a/packages/datum/lib/source/core/engine/datum_core.dart
+++ b/packages/datum/lib/source/core/engine/datum_core.dart
@@ -326,7 +326,9 @@ class Datum {
       await datum._logPendingOperationsSummary(logBuffer);
 
       logBuffer.write('└─ ✅ Datum Initialization Complete.');
-      initLogger.info(logBuffer.toString());
+      for (final line in logBuffer.toString().split('\n')) {
+        initLogger.info(line);
+      }
 
       datum._listenToEventsForMetrics();
       datum._startConnectivityMonitoring();
@@ -424,6 +426,7 @@ class Datum {
     } else {
       logBuffer.writeln('│  │  └─ ℹ️  Using custom request strategy.');
     }
+    logBuffer.writeln('│  ├─ 🚦 ${_yellow('Conflict Resolver')}: ${_green(config.defaultConflictResolver.runtimeType)}');
     logBuffer.writeln('│  ├─ ⏳ ${_yellow('Sync Timeout')}: ${_cyan(formatDuration(config.syncTimeout))}');
     logBuffer.writeln('│  ├─ ↪️  ${_yellow('User Switch')}: ${_green(config.defaultUserSwitchStrategy.name)}');
     switch (config.defaultUserSwitchStrategy) {
@@ -475,6 +478,7 @@ class Datum {
     logBuffer.writeln('├─ 📊 Sync Status & Pending Operations');
     var totalPending = 0;
     var totalItems = 0;
+    var totalSize = 0;
 
     for (final userId in allUserIds) {
       logBuffer.writeln('│  ├─ 👤 User: ${_cyan(userId)}');
@@ -512,6 +516,7 @@ class Datum {
         final storageSize = await manager.localAdapter.getStorageSize(userId: userId);
         totalItems += itemCount;
         totalPending += count;
+        totalSize += storageSize;
 
         if (itemCount > 0 || count > 0) {
           userHasContent = true;
@@ -524,7 +529,8 @@ class Datum {
         logBuffer.writeln('│  │  └─ 📭 No local data or pending operations.');
       }
     }
-    logBuffer.writeln('│  └─ 📈 Totals: Items: ${_green(totalItems)}, Pending: ${_yellow(totalPending)}');
+    final totalSizeInKb = (totalSize / 1024).toStringAsFixed(2);
+    logBuffer.writeln('│  └─ 📈 Totals: Items: ${_green(totalItems)}, Pending: ${_yellow(totalPending)}, Size: ${_yellow('$totalSizeInKb KB')}');
   }
 
   void _logObservers(StringBuffer logBuffer) {
@@ -572,8 +578,8 @@ class Datum {
 
     logBuffer?.writeln('│  └─ 🧩 Entity: ${_cyan(T)}');
     logBuffer?.writeln('│     ├─ 🏠 Local Adapter: ${_green(registration.localAdapter.runtimeType)}');
-    logBuffer?.writeln('│     ├─ ☁️   Remote Adapter: ${_green(registration.remoteAdapter.runtimeType)}');
-    logBuffer?.writeln('│     ├─ ⚖️  Conflict Resolver: ${_green(registration.conflictResolver?.runtimeType ?? 'Default (LastWriteWinsResolver)')}');
+    logBuffer?.writeln('│     ├─ ☁️ Remote Adapter: ${_green(registration.remoteAdapter.runtimeType)}');
+    logBuffer?.writeln('│     ├─ ⚖️ Conflict Resolver: ${_green(registration.conflictResolver?.runtimeType ?? 'Default (LastWriteWinsResolver)')}');
     logBuffer?.writeln('│     $lastCharForConfig─ 🔧 Custom Config: ${_green(registration.config != null)}');
 
     if (hasMiddlewares) {

--- a/packages/datum/lib/source/core/models/datum_sync_options.dart
+++ b/packages/datum/lib/source/core/models/datum_sync_options.dart
@@ -97,3 +97,23 @@ class DatumSyncOptions<T extends DatumEntityInterface> {
     );
   }
 }
+
+extension DatumSyncOptionsAdapter on DatumSyncOptions<DatumEntityInterface> {
+  /// Converts to a typed `DatumSyncOptions<T>`.
+  ///
+  /// Required because Dart generics are invariant.
+  DatumSyncOptions<T> toTyped<T extends DatumEntityInterface>() {
+    return DatumSyncOptions<T>(
+      includeDeletes: includeDeletes,
+      resolveConflicts: resolveConflicts,
+      forceFullSync: forceFullSync,
+      overrideBatchSize: overrideBatchSize,
+      timeout: timeout,
+      direction: direction,
+      query: query,
+      conflictResolver: conflictResolver != null
+          ? DatumConflictResolverAdapter<T>(conflictResolver!)
+          : null,
+    );
+  }
+}

--- a/packages/datum/lib/source/core/resolver/conflict_resolution.dart
+++ b/packages/datum/lib/source/core/resolver/conflict_resolution.dart
@@ -123,3 +123,31 @@ abstract class DatumConflictResolver<T extends DatumEntityInterface> {
     required DatumConflictContext context,
   });
 }
+
+/// Adapts a resolver from `DatumEntityInterface` → `T`.
+///
+/// Required because Dart generics are invariant.
+/// Delegates to the base resolver and converts the result to `T`.
+class DatumConflictResolverAdapter<T extends DatumEntityInterface> implements DatumConflictResolver<T> {
+  final DatumConflictResolver<DatumEntityInterface> base;
+
+  DatumConflictResolverAdapter(this.base);
+
+  @override
+  String get name => base.name;
+
+  @override
+  FutureOr<DatumConflictResolution<T>> resolve({
+    T? local,
+    T? remote,
+    required DatumConflictContext context,
+  }) async {
+    final result = await base.resolve(
+      local: local,
+      remote: remote,
+      context: context,
+    );
+
+    return result.copyWithNewType<T>();
+  }
+}


### PR DESCRIPTION
Related issue: #43 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved initialization logging with line-by-line output and additional resolver type information
  * Added local storage size metrics to pending operations summary
  * Enhanced configuration default handling for conflict resolvers and sync options

* **Chores**
  * Removed duplicate comment in configuration code
  * Minor formatting adjustment to adapter logging output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->